### PR TITLE
Allow using a environment variable secret store

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -229,7 +229,14 @@ func maybeWrapInAuthenticatingTransport(baseTransport http.RoundTripper) http.Ro
 		return baseTransport
 	}
 	// Use a transport that authenticates us as an installation.
-	authenticatingTransport, err := ghinstallation.NewKeyFromFile(baseTransport, int64(applicationId), int64(installationId), os.Getenv(envGitHubAppPrivateKeyPath))
+
+	// Read the Secret Key
+	fmt.Printf("%v", secretStore)
+	privateKey, err := secretStore.Get(envGitHubAppPrivateKeyPath)
+	if err != nil {
+		log.Warnf("Failed to read secret key from configured path: %v", err)
+	}
+	authenticatingTransport, err := ghinstallation.New(baseTransport, int64(applicationId), int64(installationId), privateKey)
 	if err != nil {
 		log.Warnf("failed to create authenticating transport: %v", err)
 		return baseTransport

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -23,6 +23,7 @@ const (
 	envGitHubStatusName                = "GITHUB_STATUS_NAME"
 	envIgnoredRepositories             = "IGNORED_REPOSITORIES"
 	envLogLevel                        = "LOG_LEVEL"
+	envSecretStoreType                 = "SECRET_STORE_TYPE" // Set to AWS_SSM for the ability to run in ECS using SSM. Empty, not set or anything else for default K8s secret
 	envLogzioTokenPath                 = "LOGZIO_TOKEN_PATH"
 	envEncryptionKeyPath               = "ENCRYPTION_KEY_PATH"
 	envUseCachingTransport             = "USE_CACHING_TRANSPORT"

--- a/internal/secrets.go
+++ b/internal/secrets.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+type SecretStore interface {
+	Get(envVariable string) ([]byte, error)
+}
+
+type EnvSecretStore struct {
+}
+
+func (s *EnvSecretStore) Get(envVariable string) ([]byte, error) {
+	return []byte(strings.ReplaceAll(os.Getenv(envVariable), "\\n", "\n")), nil
+}
+
+type FileSecretStore struct {
+}
+
+func (s *FileSecretStore) Get(envVariable string) ([]byte, error) {
+	return ioutil.ReadFile(os.Getenv(envVariable))
+}
+
+func NewSSMStore() *EnvSecretStore {
+	return &EnvSecretStore{}
+}
+
+func NewEnvSecretStore() *FileSecretStore {
+	return &FileSecretStore{}
+}

--- a/internal/slack_alerts.go
+++ b/internal/slack_alerts.go
@@ -45,12 +45,14 @@ func handlePrMergeEvent(ctx context.Context, event event) error {
 				return err
 			}
 
-			bytes, err := renderTemplate(event, alert.SlackMessage); if err != nil {
+			bytes, err := renderTemplate(event, alert.SlackMessage)
+			if err != nil {
 				return err
 			}
 
 			var msg slack.WebhookMessage
-			err = json.Unmarshal(bytes, &msg); if err != nil {
+			err = json.Unmarshal(bytes, &msg)
+			if err != nil {
 				return err
 			}
 

--- a/internal/template.go
+++ b/internal/template.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 )
 
-func renderTemplate(e event, t string) ([]byte, error){
+func renderTemplate(e event, t string) ([]byte, error) {
 	tmpl, err := template.New("test").Parse(t)
 	if err != nil {
 		return nil, err
@@ -19,4 +19,3 @@ func renderTemplate(e event, t string) ([]byte, error){
 
 	return tpl.Bytes(), nil
 }
-

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestTemplate(t *testing.T){
+func TestTemplate(t *testing.T) {
 
 	b := readGitHubExampleFile("pull_request_closed.json")
 
@@ -38,6 +38,5 @@ User:  kevholditch
 	if !strings.EqualFold(string(output), expected) {
 		t.Errorf("template not rendered correctly, expected: %s, got: %s", expected, output)
 	}
-
 
 }


### PR DESCRIPTION
We want to run the application in AWS Fargate using aws SSM
to decrypt and load secrets into the container's environment
rather than using file based K8s config.

This commit allows setting "SECRET_STORE_TYPE" to AWS_SSM
to read secrets from the env var, rather than from the path
contained in the env var.

Signed-off-by: Alistair Hey <alistair.hey@form3.tech>