### PR TITLE
Fix: Reduce notifications and add more tests

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -118,6 +118,29 @@ func TestWhenReviewApproverIsNotAContributor(t *testing.T) {
 		ExpectNoReviewRequestsMade()
 }
 
+func TestForciblyApprovedPRWithoutAnyReviewsIsPassed(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithFooAsApprovingTeamWithEmergencyRule().
+		PullRequestExists().
+		PullRequestHasNoReviews().
+		CommitsWithBobAsContributor().
+		GitHubTeamApproverRunning()
+	when.
+		SendingPRReviewSubmittedEventWithForceApproval()
+	then.
+		ExpectSuccessAnswerReturned().
+		ExpectStatusSuccessReported().
+		ExpectNoCommentsMade().
+		ExpectLabelsUpdated().
+		ExpectNoReviewRequestsMade()
+}
+
 func TestWhenPRHasNoReviewsAndAuthorIsPartOfTeam(t *testing.T) {
 	given, when, then := stages.ApiTest(t)
 
@@ -176,7 +199,7 @@ func TestWhenPRReviewedByNonTeamMemberAndAuthorsArePartOfTeam(t *testing.T) {
 		OrganisationWithTeamFoo().
 		RepoWithFooAsApprovingTeam().
 		PullRequestExists().
-		CommitsWithBobandEveAsContributor().
+		CommitsWithBobAndEveAsContributor().
 		CharlieApprovesPullRequest().
 		NoCommentsExist().
 		GitHubTeamApproverRunning()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -118,6 +118,78 @@ func TestWhenReviewApproverIsNotAContributor(t *testing.T) {
 		ExpectNoReviewRequestsMade()
 }
 
+func TestWhenPRHasNoReviewsAndAuthorIsPartOfTeam(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithFooAsApprovingTeam().
+		PullRequestExists().
+		CommitsWithBobAsContributor().
+		PullRequestHasNoReviews().
+		NoCommentsExist().
+		GitHubTeamApproverRunning()
+	when.
+		SendingApprovedPRReviewSubmittedEvent()
+	then.
+		ExpectPendingAnswerReturned().
+		ExpectStatusPendingReported().
+		ExpectNoCommentsMade().
+		ExpectLabelsUpdated().
+		ExpectNoReviewRequestsMade()
+}
+
+func TestWhenPRReviewedByAuthorNotPartOfTeam(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithFooAsApprovingTeam().
+		PullRequestExists().
+		CommitsWithCharlieAsContributor().
+		AliceApprovesPullRequest().
+		NoCommentsExist().
+		GitHubTeamApproverRunning()
+	when.
+		SendingApprovedPRReviewSubmittedEvent()
+	then.
+		ExpectSuccessAnswerReturned().
+		ExpectStatusSuccessReported().
+		ExpectNoCommentsMade().
+		ExpectLabelsUpdated().
+		ExpectNoReviewRequestsMade()
+}
+
+func TestWhenPRReviewedByNonTeamMemberAndAuthorsArePartOfTeam(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithFooAsApprovingTeam().
+		PullRequestExists().
+		CommitsWithBobandEveAsContributor().
+		CharlieApprovesPullRequest().
+		NoCommentsExist().
+		GitHubTeamApproverRunning()
+	when.
+		SendingApprovedPRReviewSubmittedEvent()
+	then.
+		ExpectPendingAnswerReturned().
+		ExpectStatusPendingReported().
+		ExpectNoCommentsMade().
+		ExpectLabelsUpdated().
+		ExpectNoReviewRequestsMade()
+}
+
 func TestGitHubTeamApproverCleansUpOldIgnoredReviewsComments(t *testing.T) {
 	given, when, then := stages.ApiTest(t)
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -29,10 +29,10 @@ var (
 	errIgnoredEvent = fmt.Errorf("ignoring event: unsupported type")
 )
 
-func (api *Api) HandleHealth(w http.ResponseWriter, req *http.Request) {
+func (api *API) HandleHealth(w http.ResponseWriter, req *http.Request) {
 	sendHttpOkResponse(w)
 }
-func (api *Api) Handle(w http.ResponseWriter, req *http.Request) {
+func (api *API) Handle(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		sendHttpMethodNotAllowedResponse(w, fmt.Errorf("unsupported method %q", req.Method))
 		return
@@ -116,13 +116,14 @@ func (api *Api) Handle(w http.ResponseWriter, req *http.Request) {
 			WithError(err).
 			Warn("failed to handle event")
 		sendHttpInternalServerErrorResponse(w, fmt.Errorf("failed to handle event: %w", err))
+		return
 	}
 
 	sendHttpOkWithStatusResponse(w, status)
 	return
 }
 
-func (api *Api) validateSignature(signature string, body []byte) error {
+func (api *API) validateSignature(signature string, body []byte) error {
 	if api.githubWebhookSecretToken == nil {
 		// TODO we should make this more clear, following what we had from before now
 		// see setGitHubAppSecret api comments

--- a/internal/api/pr_handler.go
+++ b/internal/api/pr_handler.go
@@ -26,12 +26,12 @@ const (
 )
 
 type PullRequestEventHandler struct {
-	api    *Api
+	api    *API
 	log    *logrus.Entry
 	client *ghclient.Client
 }
 
-func NewPullRequestEventHandler(api *Api, log *logrus.Entry, client *ghclient.Client) *PullRequestEventHandler {
+func NewPullRequestEventHandler(api *API, log *logrus.Entry, client *ghclient.Client) *PullRequestEventHandler {
 	return &PullRequestEventHandler{
 		api:    api,
 		log:    log,

--- a/internal/api/pr_handler.go
+++ b/internal/api/pr_handler.go
@@ -46,6 +46,7 @@ func (handler *PullRequestEventHandler) handleEvent(ctx context.Context, eventTy
 		ownerLogin = event.GetRepo().GetOwner().GetLogin()
 		repoName   = event.GetRepo().GetName()
 		prNumber   = event.GetPullRequest().GetNumber()
+		prAuthor   = event.GetPullRequest().GetUser()
 	)
 
 	// Make sure the combination of event type and action is supported.
@@ -59,7 +60,7 @@ func (handler *PullRequestEventHandler) handleEvent(ctx context.Context, eventTy
 	prBody := event.GetPullRequest().GetBody()
 	prLabels := getLabelNames(event.GetPullRequest().Labels)
 
-	pr := approval.NewPR(ownerLogin, repoName, prTargetBranch, prBody, prNumber, prLabels)
+	pr := approval.NewPR(ownerLogin, repoName, prTargetBranch, prBody, prNumber, prLabels, prAuthor)
 	app := approval.NewApproval(handler.log, handler.client)
 	result, err := app.ComputeApprovalStatus(ctx, pr)
 	if errors.Is(err, ghclient.ErrNoConfigurationFile) {

--- a/internal/api/pr_merge_handler.go
+++ b/internal/api/pr_merge_handler.go
@@ -12,12 +12,12 @@ import (
 )
 
 type MergeEventHandler struct {
-	api *Api
+	api *API
 	log *logrus.Entry
 	client *github.Client
 }
 
-func NewMergeEventHandler(api *Api, log *logrus.Entry, client *github.Client) *MergeEventHandler {
+func NewMergeEventHandler(api *API, log *logrus.Entry, client *github.Client) *MergeEventHandler {
 	return &MergeEventHandler{
 		api: api,
 		log: log,

--- a/internal/api/stages/api_stage.go
+++ b/internal/api/stages/api_stage.go
@@ -124,6 +124,47 @@ func (s *ApiStage) RepoWithFooAsApprovingTeam() *ApiStage {
 	return s
 }
 
+func (s *ApiStage) RepoWithFooAsApprovingTeamWithEmergencyRule() *ApiStage {
+	require.NotNil(s.t, s.fakeGitHub.Org())
+	approvingTeam := *s.fakeGitHub.Org().Teams[0].Name
+
+	repo := &fakegithub.Repo{
+		Name: "some-service",
+
+		ApproverCfg: &approverCfg.Configuration{
+			PullRequestApprovalRules: []approverCfg.PullRequestApprovalRule{
+				{
+					TargetBranches: []string{"master"},
+					Rules: []approverCfg.Rule{
+						{
+							ApprovalMode:         approverCfg.ApprovalModeRequireAny,
+							Regex:                `- \[x\] Yes - this change impacts customers`,
+							ApprovingTeamHandles: []string{approvingTeam},
+							Labels:               []string{},
+						},
+						{
+							ApprovalMode:         approverCfg.ApprovalModeRequireAny,
+							Regex:                `- \[x\] Yes - Emergency`,
+							ApprovingTeamHandles: []string{"CAB - Foo"},
+							Labels:               []string{},
+							ForceApproval:        true,
+						},
+					},
+				},
+			},
+		},
+	}
+	s.fakeGitHub.SetRepo(repo)
+	s.fakeGitHub.SetRepoContents([]*github.RepositoryContent{
+		{
+			Name:        github.String("GITHUB_TEAM_APPROVER.yaml"),
+			DownloadURL: github.String(fmt.Sprintf("%s/master/%s", s.fakeGitHub.RepoURL(), approverCfg.ConfigurationFilePath)),
+		},
+	})
+
+	return s
+}
+
 func (s *ApiStage) RepoWithoutConfigurationFile() *ApiStage {
 	require.NotNil(s.t, s.fakeGitHub.Org())
 
@@ -196,7 +237,6 @@ func (s *ApiStage) ExpectBadRequestReturned() {
 	require.Equal(s.t, http.StatusBadRequest, s.resp.StatusCode)
 }
 
-
 func (s *ApiStage) CommitsWithBobAsContributor() *ApiStage {
 	commits := []*github.RepositoryCommit{
 		{
@@ -233,7 +273,7 @@ func (s *ApiStage) CommitsWithCharlieAsContributor() *ApiStage {
 	return s
 }
 
-func (s *ApiStage) CommitsWithBobandEveAsContributor() *ApiStage {
+func (s *ApiStage) CommitsWithBobAndEveAsContributor() *ApiStage {
 	commits := []*github.RepositoryCommit{
 		{
 			SHA: github.String("some-sha-1"),
@@ -328,8 +368,6 @@ func (s *ApiStage) PullRequestHasNoReviews() *ApiStage {
 	return s
 }
 
-
-
 func (s *ApiStage) PullRequestExists() *ApiStage {
 
 	s.fakeGitHub.SetPR(&fakegithub.PR{
@@ -368,6 +406,49 @@ func (s *ApiStage) SendingApprovedPRReviewSubmittedEvent() *ApiStage {
 							Regex:                `- [x] Yes - this change impacts customers`,
 							ApprovingTeamHandles: []string{"CAB - Foo"},
 							Labels:               []string{},
+						},
+					},
+				},
+			},
+		},
+	}
+	payload := r.Create(s.t)
+
+	c := newClient(s.t, s.app.URL(), s.WebHookSecret)
+	s.resp = c.sendEvent(payload, "pull_request_review")
+
+	return s
+}
+
+func (s *ApiStage) SendingPRReviewSubmittedEventWithForceApproval() *ApiStage {
+	require.NotNil(s.t, s.fakeGitHub.Org())
+	require.NotNil(s.t, s.fakeGitHub.Repo())
+	require.NotNil(s.t, s.fakeGitHub.PR())
+
+	targetBranch := "master"
+	s.labels = []string{"foo", "bar", "needs-cab-approval"}
+
+	r := fakegithub.ReviewEvent{
+		OwnerLogin: s.fakeGitHub.Org().OwnerName,
+		RepoName:   s.fakeGitHub.Repo().Name,
+		PRNumber:   s.fakeGitHub.PR().PRNumber,
+
+		Action:         "submitted",
+		CommitSHA:      s.fakeGitHub.PR().PRCommit,
+		LabelNames:     s.labels,
+		PRMerged:       false,
+		PRTargetBranch: targetBranch,
+		PRCfg: &approverCfg.Configuration{
+			PullRequestApprovalRules: []approverCfg.PullRequestApprovalRule{
+				{
+					TargetBranches: []string{targetBranch},
+					Rules: []approverCfg.Rule{
+						{
+							ApprovalMode:         approverCfg.ApprovalModeRequireAny,
+							Regex:                `- [x] Yes - Emergency`,
+							ApprovingTeamHandles: []string{"CAB - Foo"},
+							Labels:               []string{"needs-cab-approval"},
+							ForceApproval:        true,
 						},
 					},
 				},

--- a/internal/api/stages/api_stage.go
+++ b/internal/api/stages/api_stage.go
@@ -196,6 +196,7 @@ func (s *ApiStage) ExpectBadRequestReturned() {
 	require.Equal(s.t, http.StatusBadRequest, s.resp.StatusCode)
 }
 
+
 func (s *ApiStage) CommitsWithBobAsContributor() *ApiStage {
 	commits := []*github.RepositoryCommit{
 		{
@@ -206,6 +207,42 @@ func (s *ApiStage) CommitsWithBobAsContributor() *ApiStage {
 			},
 			Committer: &github.User{
 				Login: github.String("bob"),
+			},
+		},
+	}
+	s.fakeGitHub.SetCommits(commits)
+
+	return s
+}
+
+func (s *ApiStage) CommitsWithCharlieAsContributor() *ApiStage {
+	commits := []*github.RepositoryCommit{
+		{
+			SHA: github.String("some-sha-1"),
+
+			Author: &github.User{
+				Login: github.String("charlie"),
+			},
+			Committer: &github.User{
+				Login: github.String("charlie"),
+			},
+		},
+	}
+	s.fakeGitHub.SetCommits(commits)
+
+	return s
+}
+
+func (s *ApiStage) CommitsWithBobandEveAsContributor() *ApiStage {
+	commits := []*github.RepositoryCommit{
+		{
+			SHA: github.String("some-sha-1"),
+
+			Author: &github.User{
+				Login: github.String("bob"),
+			},
+			Committer: &github.User{
+				Login: github.String("eve"),
 			},
 		},
 	}
@@ -268,6 +305,30 @@ func (s *ApiStage) AliceApprovesPullRequest() *ApiStage {
 
 	return s
 }
+
+func (s *ApiStage) CharlieApprovesPullRequest() *ApiStage {
+	reviews := []*github.PullRequestReview{
+		{
+			State: github.String("APPROVED"),
+			User: &github.User{
+				Login: github.String("charlie"),
+			},
+		},
+	}
+
+	s.fakeGitHub.SetReviews(reviews)
+
+	return s
+}
+
+func (s *ApiStage) PullRequestHasNoReviews() *ApiStage {
+	var reviews []*github.PullRequestReview
+	s.fakeGitHub.SetReviews(reviews)
+
+	return s
+}
+
+
 
 func (s *ApiStage) PullRequestExists() *ApiStage {
 

--- a/internal/api/stages/fakegithub/handlers.go
+++ b/internal/api/stages/fakegithub/handlers.go
@@ -91,8 +91,6 @@ func (f *FakeGitHub) reviewsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	require.NotEmpty(f.t, f.reviews)
-
 	w.Header().Set("Content-Type", "application/json")
 	payload, err := json.Marshal(f.reviews)
 	require.NoError(f.t, err)


### PR DESCRIPTION
Only Mention ignored reviewers who approved the PR
    
Before this change, a contributor would be mentioned regardless if
they approved a PR or not.
    
With this change, we limit the mention to only mention the
contributors who have approved the PR.

Other improvements:
* Add test with new test structure to cover Forcibly approved PRs
* Add more logging on happy path during startup
