### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "08:00"
+      timezone: Europe/London
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "form3tech-oss/Contributors-codeowners"


### PR DESCRIPTION
I want to add Dependabot to this project so we can stay on top of dependencies changes.
Updating the dependencies more frequently could help us resolve issues like this one faster: https://github.com/form3tech-oss/github-team-approver/pull/32