### PR TITLE
WIP: use unique field name

### DIFF
--- a/internal/api/github/client.go
+++ b/internal/api/github/client.go
@@ -75,10 +75,10 @@ func (c *Client) GetPullRequestReviews(ctx context.Context, ownerLogin, repoName
 
 	logger := log.WithFields(
 		log.Fields{
-			"pr":       prNumber,
-			"repo":     fmt.Sprintf("%s/%s", ownerLogin, repoName),
-			"api":      "PullRequests.ListReviews",
-			"per_page": opts.PerPage,
+			"pr":         prNumber,
+			"repository": fmt.Sprintf("%s/%s", ownerLogin, repoName),
+			"api":        "PullRequests.ListReviews",
+			"per_page":   opts.PerPage,
 		})
 
 	for {
@@ -116,10 +116,10 @@ func (c *Client) GetPullRequestCommitFiles(ctx context.Context, ownerLogin, repo
 
 	logger := log.WithFields(
 		log.Fields{
-			"pr":       prNumber,
-			"repo":     fmt.Sprintf("%s/%s", ownerLogin, repoName),
-			"api":      "PullRequests.ListFiles",
-			"per_page": opts.PerPage,
+			"pr":         prNumber,
+			"repository": fmt.Sprintf("%s/%s", ownerLogin, repoName),
+			"api":        "PullRequests.ListFiles",
+			"per_page":   opts.PerPage,
 		})
 
 	for {
@@ -213,11 +213,11 @@ func (c *Client) getPRCommitsPage(ctx context.Context, owner, repo string, prNum
 
 	log.WithFields(
 		log.Fields{
-			"pr":       prNumber,
-			"repo":     fmt.Sprintf("%s/%s", owner, repo),
-			"api":      "PullRequests.ListCommits",
-			"per_page": opts.PerPage,
-			"page":     opts.Page,
+			"pr":         prNumber,
+			"repository": fmt.Sprintf("%s/%s", owner, repo),
+			"api":        "PullRequests.ListCommits",
+			"per_page":   opts.PerPage,
+			"page":       opts.Page,
 		}).Tracef("requesting")
 
 	commits, resp, err := c.githubClient.PullRequests.ListCommits(
@@ -415,11 +415,11 @@ func (c *Client) getPRCommentsPage(ctx context.Context, owner, repo string, prNu
 
 	log.WithFields(
 		log.Fields{
-			"pr":       prNumber,
-			"repo":     fmt.Sprintf("%s/%s", owner, repo),
-			"api":      "Issues.ListComments",
-			"per_page": opts.PerPage,
-			"page":     opts.Page,
+			"pr":         prNumber,
+			"repository": fmt.Sprintf("%s/%s", owner, repo),
+			"api":        "Issues.ListComments",
+			"per_page":   opts.PerPage,
+			"page":       opts.Page,
 		}).Tracef("requesting")
 
 	comments, resp, err := c.githubClient.Issues.ListComments(ctxTimeout, owner, repo, prNumber, opts)
@@ -474,10 +474,10 @@ func (c *Client) GetLabels(ctx context.Context, ownerLogin, repoName string, prN
 
 	logger := log.WithFields(
 		log.Fields{
-			"pr":       prNumber,
-			"repo":     fmt.Sprintf("%s/%s", ownerLogin, repoName),
-			"api":      "Issues.ListLabelsByIssue",
-			"per_page": opts.PerPage,
+			"pr":         prNumber,
+			"repository": fmt.Sprintf("%s/%s", ownerLogin, repoName),
+			"api":        "Issues.ListLabelsByIssue",
+			"per_page":   opts.PerPage,
 		})
 
 	for {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -16,7 +16,7 @@ const (
 	logFieldDeliveryID  = "delivery_id"
 	logFieldEventType   = "event_type"
 	logFieldPR          = "pr"
-	logFieldRepo        = "repo"
+	logFieldRepo        = "repository"
 	logFieldServiceName = "service_name"
 
 	httpHeaderXFinalStatus    = "X-Final-Status"


### PR DESCRIPTION
It is naive theory but would renaming log field `repo` -> `repository` solve the clash for `repo` field in the logzio index between GTA & CodeInsight (more [details](https://github.com/form3tech/tooling-team/issues/580#issuecomment-993631709))?