### PR TITLE
Report in status description when a repository configuration references invalid team handles

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,8 +1,9 @@
 package api_test
 
 import (
-	"github.com/form3tech-oss/github-team-approver/internal/api/stages"
 	"testing"
+
+	"github.com/form3tech-oss/github-team-approver/internal/api/stages"
 )
 
 func TestWhenSendingInvalidSignatures(t *testing.T) {
@@ -260,4 +261,24 @@ func TestGitHubTeamApproverCleansUpOldIgnoredReviewsComments(t *testing.T) {
 		ExpectCommentAliceIgnoredAsReviewer().
 		ExpectLabelsUpdated().
 		ExpectedReviewRequestsMadeForFoo()
+}
+
+func TestGitHubTeamApproverReportsInvalidTeamHandlesInConfiguration(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithConfigurationReferencingInvalidTeamHandles().
+		PullRequestExists().
+		NoReviewsExist().
+		GitHubTeamApproverRunning()
+	when.
+		SendingPREvent()
+	then.
+		ExpectPendingAnswerReturned().
+		ExpectStatusPendingReported().
+		ExpectInvalidTeamHandleInStatusDescription()
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -278,7 +278,25 @@ func TestGitHubTeamApproverReportsInvalidTeamHandlesInConfiguration(t *testing.T
 	when.
 		SendingPREvent()
 	then.
-		ExpectPendingAnswerReturned().
-		ExpectStatusPendingReported().
+		ExpectErrorAnswerReturned().
+		ExpectStatusErrorReported().
 		ExpectInvalidTeamHandleInStatusDescription()
+}
+
+func TestNoTeamRequestedForReviewIfConfigurationIsInvalid(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithConfigurationReferencingInvalidTeamHandles().
+		PullRequestExists().
+		NoReviewsExist().
+		GitHubTeamApproverRunning()
+	when.
+		SendingPREvent()
+	then.
+		ExpectNoReviewRequestsMade()
 }

--- a/internal/api/approval/approval.go
+++ b/internal/api/approval/approval.go
@@ -3,12 +3,13 @@ package approval
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
 
@@ -170,7 +171,8 @@ func (a *Approval) ComputeApprovalStatus(ctx context.Context, pr *PR) (*Result, 
 		for _, handle := range rule.ApprovingTeamHandles {
 			teamName, err := getTeamNameFromTeamHandle(teams, handle)
 			if err != nil {
-				return nil, err
+				state.addInvalidTeamHandle(handle)
+				continue
 			}
 			// Grab the list of members on the current approving team.
 			members, err := a.client.GetTeamMembers(ctx, teams, pr.OwnerLogin, teamName)

--- a/internal/api/approval/approval.go
+++ b/internal/api/approval/approval.go
@@ -26,6 +26,7 @@ const (
 	statusEventDescriptionNoRulesForTargetBranch = "No rules are defined for the target branch."
 	StatusEventStatusPending                     = "pending"
 	StatusEventStatusSuccess                     = "success"
+	StatusEventStatusError                       = "error"
 )
 
 var (

--- a/internal/api/stages/api_stage.go
+++ b/internal/api/stages/api_stage.go
@@ -293,6 +293,13 @@ func (s *ApiStage) ExpectPendingAnswerReturned() *ApiStage {
 	return s
 }
 
+func (s *ApiStage) ExpectErrorAnswerReturned() *ApiStage {
+	require.NotNil(s.t, s.resp)
+	require.Equal(s.t, http.StatusOK, s.resp.StatusCode)
+	require.Equal(s.t, approval.StatusEventStatusError, s.resp.Header.Get(httpHeaderXFinalStatus))
+	return s
+}
+
 func (s *ApiStage) ExpectSuccessAnswerReturned() *ApiStage {
 	require.NotNil(s.t, s.resp)
 	require.Equal(s.t, http.StatusOK, s.resp.StatusCode)
@@ -607,6 +614,13 @@ func (s *ApiStage) ExpectLabelsUpdated() *ApiStage {
 func (s *ApiStage) ExpectStatusPendingReported() *ApiStage {
 	status := s.fakeGitHub.ReportedStatus()
 	require.Equal(s.t, approval.StatusEventStatusPending, *(status.State))
+	require.Equal(s.t, botName, *(status.Context))
+	return s
+}
+
+func (s *ApiStage) ExpectStatusErrorReported() *ApiStage {
+	status := s.fakeGitHub.ReportedStatus()
+	require.Equal(s.t, approval.StatusEventStatusError, *(status.State))
 	require.Equal(s.t, botName, *(status.Context))
 	return s
 }


### PR DESCRIPTION
When the configuration references invalid team handles (teams are resolved either by `name` or by `slug`) the `github-team-approver` handler fails with a 500 error and the error message is only visible in logs.

With this change, when a PR is opened against a repository with a configuration referencing invalid team handles, the PR status is marked as `pending` and the description set to a readable message.
