### PR TITLE
Add support for ignoring Reopeners as approvers

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -214,6 +214,30 @@ func TestWhenReviewApproverIsNotACoAuthor(t *testing.T) {
 		ExpectNoReviewRequestsMade()
 }
 
+func TestWhenReviewApproverIsReopener(t *testing.T) {
+	given, when, then := stages.ApiTest(t)
+
+	given.
+		EncryptionKeyExists().
+		GitHubWebHookTokenExists().
+		FakeGHRunning().
+		OrganisationWithTeamFoo().
+		RepoWithFooAsApprovingTeam().
+		PullRequestExists().
+		NoCommentsExist().
+		CommitsWithBobAsCoAuthor().
+		AliceApprovesPullRequest().
+		EventsWithAliceAsReopener().
+		GitHubTeamApproverRunning()
+	when.
+		SendingApprovedPRReviewSubmittedEvent()
+	then.
+		ExpectPendingAnswerReturned().
+		ExpectStatusPendingReported().
+		ExpectCommentAliceIgnoredAsReviewer().
+		ExpectLabelsUpdated()
+}
+
 func TestForciblyApprovedPRWithoutAnyReviewsIsPassed(t *testing.T) {
 	given, when, then := stages.ApiTest(t)
 

--- a/internal/api/approval/approval.go
+++ b/internal/api/approval/approval.go
@@ -431,7 +431,7 @@ func filterAllowedAndIgnoreReviewers(members []*github.User, commits []*github.R
 func findReOpeners(events []*github.IssueEvent) map[string]bool {
 	reopeners := map[string]bool{}
 	for _, e := range events {
-		if e != nil && e.Event != nil && *e.Event == "reopened" {
+		if e.GetEvent() == "reopened" {
 			reopeners[e.GetActor().GetLogin()] = true
 		}
 	}

--- a/internal/api/approval/approval.go
+++ b/internal/api/approval/approval.go
@@ -387,24 +387,25 @@ func getTeamNameFromTeamHandle(teams []*github.Team, v string) (string, error) {
 }
 
 func (a *Approval) allowedAndIgnoreReviewers(ctx context.Context, pr *PR, members []*github.User, ignoreContributors bool) ([]string, []string, error) {
-	if !ignoreContributors {
-		var allowedMembers []string
-		for _, m := range members {
-			allowedMembers = append(allowedMembers, m.GetLogin())
+	commits := []*github.RepositoryCommit{}
+	if ignoreContributors {
+		var err error
+		commits, err = a.client.GetPRCommits(ctx, pr.OwnerLogin, pr.RepoName, pr.Number)
+		if err != nil {
+			return nil, nil, err
 		}
-		return allowedMembers, []string{}, nil
 	}
 
-	commits, err := a.client.GetPRCommits(ctx, pr.OwnerLogin, pr.RepoName, pr.Number)
+	events, err := a.client.GetIssuesEvents(ctx, pr.OwnerLogin, pr.RepoName, pr.Number)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	allowed, ignored := filterAllowedAndIgnoreReviewers(members, commits)
+	allowed, ignored := filterAllowedAndIgnoreReviewers(members, commits, events)
 	return allowed, ignored, nil
 }
 
-func filterAllowedAndIgnoreReviewers(members []*github.User, commits []*github.RepositoryCommit) ([]string, []string) {
+func filterAllowedAndIgnoreReviewers(members []*github.User, commits []*github.RepositoryCommit, events []*github.IssueEvent) ([]string, []string) {
 	authors := map[string]bool{}
 	for _, c := range commits {
 		authors[c.GetCommitter().GetLogin()] = true
@@ -413,11 +414,11 @@ func filterAllowedAndIgnoreReviewers(members []*github.User, commits []*github.R
 		}
 	}
 
+	reopeners := findReOpeners(events)
 	var allowed, ignored []string
-
 	for _, m := range members {
 		login := m.GetLogin()
-		if _, ok := authors[login]; !ok {
+		if ok := authors[login] || reopeners[login]; !ok {
 			allowed = append(allowed, login)
 		} else {
 			ignored = append(ignored, login)
@@ -425,6 +426,16 @@ func filterAllowedAndIgnoreReviewers(members []*github.User, commits []*github.R
 	}
 
 	return allowed, ignored
+}
+
+func findReOpeners(events []*github.IssueEvent) map[string]bool {
+	reopeners := map[string]bool{}
+	for _, e := range events {
+		if e != nil && e.Event != nil && *e.Event == "reopened" {
+			reopeners[e.GetActor().GetLogin()] = true
+		}
+	}
+	return reopeners
 }
 
 func findCoAuthors(msg string) []string {

--- a/internal/api/github/client.go
+++ b/internal/api/github/client.go
@@ -300,7 +300,7 @@ func (c *Client) GetTeamMembers(ctx context.Context, teams []*github.Team, organ
 	return users, nil
 }
 
-func (c* Client) GetIssuesEvents(ctx context.Context, owner, repo string, number int) ([]*github.IssueEvent, error) {
+func (c *Client) GetIssuesEvents(ctx context.Context, owner, repo string, number int) ([]*github.IssueEvent, error) {
 	var events []*github.IssueEvent
 	ctxTimeout, fn := context.WithTimeout(ctx, DefaultGitHubOperationTimeout)
 	defer fn()
@@ -328,7 +328,7 @@ func (c *Client) getIssuesEventsPage(ctx context.Context, owner, repo string, nu
 	}
 	log.WithFields(
 		log.Fields{
-			"issue":       number,
+			"issue":    number,
 			"repo":     fmt.Sprintf("%s/%s", owner, repo),
 			"api":      "Issues.ListIssueEvents",
 			"per_page": opts.PerPage,
@@ -368,7 +368,7 @@ func (c *Client) ReportIgnoredReviews(ctx context.Context, owner, repo string, p
 		return nil
 	}
 
-	title := "Following reviewers have been ignored as they are also authors in the PR:\n"
+	title := "Following reviewers have been ignored as they either contributed to or reopened the PR:\n"
 
 	err := c.removeOldBotComments(ctx, owner, repo, prNumber, title)
 	if err != nil {

--- a/internal/api/github/client.go
+++ b/internal/api/github/client.go
@@ -300,6 +300,50 @@ func (c *Client) GetTeamMembers(ctx context.Context, teams []*github.Team, organ
 	return users, nil
 }
 
+func (c* Client) GetIssuesEvents(ctx context.Context, owner, repo string, number int) ([]*github.IssueEvent, error) {
+	var events []*github.IssueEvent
+	ctxTimeout, fn := context.WithTimeout(ctx, DefaultGitHubOperationTimeout)
+	defer fn()
+
+	nextPage := 1
+	for nextPage != 0 {
+		eventsPage, next, err := c.getIssuesEventsPage(ctxTimeout, owner, repo, number, nextPage)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, eventsPage...)
+		nextPage = next
+	}
+
+	return events, nil
+}
+
+func (c *Client) getIssuesEventsPage(ctx context.Context, owner, repo string, number int, page int) ([]*github.IssueEvent, int, error) {
+	ctxTimeout, cancel := context.WithTimeout(ctx, DefaultGitHubOperationTimeout)
+	defer cancel()
+
+	opts := &github.ListOptions{
+		Page:    page,
+		PerPage: defaultListOptionsPerPage,
+	}
+	log.WithFields(
+		log.Fields{
+			"issue":       number,
+			"repo":     fmt.Sprintf("%s/%s", owner, repo),
+			"api":      "Issues.ListIssueEvents",
+			"per_page": opts.PerPage,
+			"page":     opts.Page,
+		}).Tracef("requesting")
+
+	events, resp, err := c.githubClient.Issues.ListIssueEvents(
+		ctxTimeout, owner, repo, number, opts)
+	if err != nil {
+		return nil, 0, fmt.Errorf("getIssuesEventsPage: %w", err)
+	}
+
+	return events, resp.NextPage, nil
+}
+
 func (c *Client) ReportStatus(ctx context.Context, ownerLogin, repoName, statusesURL, status, description string) error {
 	n := os.Getenv(envGitHubStatusName)
 	v := &github.RepoStatus{

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -48,6 +48,7 @@ func Test_Handle(t *testing.T) {
 			eventSignature: "sha256=6d4d96d879720606802102a5892b51634c25d52f7827d2d9d0113cef17709c0e",
 			pacts: []pacttesting.Pact{
 				"pull_request_opened_pending",
+				"issue_events_pr_5",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusPending,
@@ -70,6 +71,7 @@ func Test_Handle(t *testing.T) {
 			eventSignature: "sha256=802a01c378001fbbbea8f59e7d5eab688550bcbd097491abc907d8850cef6e17",
 			pacts: []pacttesting.Pact{
 				"pull_request_review_submitted_approved",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusSuccess,
@@ -82,6 +84,7 @@ func Test_Handle(t *testing.T) {
 			eventSignature: "sha256=802a01c378001fbbbea8f59e7d5eab688550bcbd097491abc907d8850cef6e17",
 			pacts: []pacttesting.Pact{
 				"pull_request_review_submitted_pending",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusPending,
@@ -94,6 +97,7 @@ func Test_Handle(t *testing.T) {
 			eventSignature: "sha256=c4d9e2a311de0322c4b7c09c1a2239d23668542c9caf187be03c7acb62f3ca5b",
 			pacts: []pacttesting.Pact{
 				"pull_request_review_submitted_force_approval",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusSuccess,
@@ -118,6 +122,7 @@ func Test_Handle(t *testing.T) {
 			eventSignature: "sha256=802a01c378001fbbbea8f59e7d5eab688550bcbd097491abc907d8850cef6e17",
 			pacts: []pacttesting.Pact{
 				"pull_request_review_submitted_approval_mode_require_any",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusSuccess,
@@ -152,6 +157,7 @@ func Test_Handle(t *testing.T) {
 				"pull_request_get_comments_pr_7",
 				"pull_request_post_comment_pr_7",
 				"pull_request_review_submitted_alice_approved",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusPending,
@@ -165,6 +171,7 @@ func Test_Handle(t *testing.T) {
 			pacts: []pacttesting.Pact{
 				"pull_request_commits_alice_contributed",
 				"pull_request_review_submitted_alice_bob_approved",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusSuccess,
@@ -178,6 +185,7 @@ func Test_Handle(t *testing.T) {
 			pacts: []pacttesting.Pact{
 				"pull_request_commits_alice_coauthor",
 				"pull_request_review_submitted_alice_bob_approved",
+				"issue_events_pr_7",
 			},
 
 			expectedFinalStatus: approval.StatusEventStatusSuccess,

--- a/internal/api/pacts/issue_events_pr_5.json
+++ b/internal/api/pacts/issue_events_pr_5.json
@@ -1,0 +1,69 @@
+{
+    "provider": {
+        "name": "github-api"
+    },
+    "consumer": {
+        "name": "github-team-approver"
+    },
+    "interactions": [
+        {
+            "description": "Get events (#5)",
+            "request": {
+                "method": "GET",
+                "path": "/repos/form3tech/github-team-approver-test/issues/5/events"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json; charset=utf-8"
+                },
+                "body": [
+                    {
+                        "actor": {
+                            "login": "alice"
+                        },
+                        "event": "closed"
+                    },
+                    {
+                        "actor": {
+                            "login": "eve"
+                        },
+                        "event": "reopened"
+                    },
+                    {
+                        "actor": {
+                            "login": "alice"
+                        },
+                        "event": "labeled"
+                    },
+                    {
+                        "actor": {
+                            "login": "bob"
+                        },
+                        "event": "closed"
+                    },
+                    {
+                        "actor": {
+                            "login": "eve"
+                        },
+                        "event": "reopened"
+                    },
+                    {
+                        "actor": {
+                            "login": "bob"
+                        },
+                        "event": "closed"
+                    }
+                ]
+            }
+        }
+    ],
+    "metadata": {
+        "pact-specification": {
+            "version": "3.0.0"
+        },
+        "pact-jvm": {
+            "version": "3.0.0"
+        }
+    }
+}

--- a/internal/api/pacts/issue_events_pr_7.json
+++ b/internal/api/pacts/issue_events_pr_7.json
@@ -1,0 +1,69 @@
+{
+    "provider": {
+        "name": "github-api"
+    },
+    "consumer": {
+        "name": "github-team-approver"
+    },
+    "interactions": [
+        {
+            "description": "Get events (#7)",
+            "request": {
+                "method": "GET",
+                "path": "/repos/form3tech/github-team-approver-test/issues/7/events"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application/json; charset=utf-8"
+                },
+                "body": [
+                    {
+                        "actor": {
+                            "login": "alice"
+                        },
+                        "event": "closed"
+                    },
+                    {
+                        "actor": {
+                            "login": "eve"
+                        },
+                        "event": "reopened"
+                    },
+                    {
+                        "actor": {
+                            "login": "alice"
+                        },
+                        "event": "labeled"
+                    },
+                    {
+                        "actor": {
+                            "login": "bob"
+                        },
+                        "event": "closed"
+                    },
+                    {
+                        "actor": {
+                            "login": "eve"
+                        },
+                        "event": "reopened"
+                    },
+                    {
+                        "actor": {
+                            "login": "bob"
+                        },
+                        "event": "closed"
+                    }
+                ]
+            }
+        }
+    ],
+    "metadata": {
+        "pact-specification": {
+            "version": "3.0.0"
+        },
+        "pact-jvm": {
+            "version": "3.0.0"
+        }
+    }
+}

--- a/internal/api/stages/api_stage.go
+++ b/internal/api/stages/api_stage.go
@@ -20,7 +20,7 @@ const (
 	botName                = "github-team-approver"
 	httpHeaderXFinalStatus = "X-Final-Status"
 
-	ignoredReviewerMsg = "Following reviewers have been ignored as they are also authors in the PR:"
+	ignoredReviewerMsg = "Following reviewers have been ignored as they either contributed to or reopened the PR:"
 )
 
 type ApiStage struct {

--- a/internal/api/stages/api_stage.go
+++ b/internal/api/stages/api_stage.go
@@ -463,6 +463,23 @@ func (s *ApiStage) commitsWithAuthorAndCoAuthor(author, coauthor string) *ApiSta
 	return s
 }
 
+func (s *ApiStage) EventsWithAliceAsReopener() *ApiStage {
+	return s.eventsWithReopener("alice")
+}
+
+func (s *ApiStage) eventsWithReopener(reopener string) *ApiStage {
+	events := []*github.IssueEvent{
+		{
+			Actor: &github.User{
+				Login: github.String(reopener),
+			},
+			Event: github.String("reopened"),
+		},
+	}
+	s.fakeGitHub.SetEvents(events)
+	return s
+}
+
 func (s *ApiStage) NoCommentsExist() *ApiStage {
 	s.fakeGitHub.SetIssueComments([]*github.IssueComment{})
 	return s
@@ -543,6 +560,7 @@ func (s *ApiStage) PullRequestExists() *ApiStage {
 			},
 		},
 	})
+	s.fakeGitHub.SetEvents([]*github.IssueEvent{})
 
 	return s
 }

--- a/internal/api/stages/fakegithub/github.go
+++ b/internal/api/stages/fakegithub/github.go
@@ -51,6 +51,7 @@ type FakeGitHub struct {
 	commits       []*github.RepositoryCommit
 	reviews       []*github.PullRequestReview
 	issueComments []*github.IssueComment
+	events        []*github.IssueEvent
 
 	reportedStatus         *github.RepoStatus
 	reportedComment        *github.IssueComment
@@ -116,6 +117,11 @@ func (f *FakeGitHub) SetCommits(r []*github.RepositoryCommit) {
 
 	// only expose handlers when expected data is there
 	f.mux.HandleFunc(f.commitsURL(), f.commitsHandler)
+}
+
+func (f *FakeGitHub) SetEvents(r []*github.IssueEvent) {
+	f.events = r
+	f.mux.HandleFunc(f.issueEventsURL(), f.issueEventsHandler)
 }
 
 func (f *FakeGitHub) SetReviews(r []*github.PullRequestReview) {

--- a/internal/api/stages/fakegithub/handlers.go
+++ b/internal/api/stages/fakegithub/handlers.go
@@ -205,3 +205,18 @@ func (f *FakeGitHub) prFilesHandler(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(payload)
 	require.NoError(f.t, err)
 }
+
+func (f *FakeGitHub) issueEventsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	require.NotNil(f.t, f.events)
+
+	w.Header().Set("Content-Type", "application/json")
+	payload, err := json.Marshal(f.events)
+	require.NoError(f.t, err)
+	_, err = w.Write(payload)
+	require.NoError(f.t, err)
+}

--- a/internal/api/stages/fakegithub/paths.go
+++ b/internal/api/stages/fakegithub/paths.go
@@ -53,3 +53,7 @@ func (f *FakeGitHub) repoFullName() string {
 func (f *FakeGitHub) prFilesURL() string {
 	return fmt.Sprintf("/repos/%s/pulls/%d/files", f.repoFullName(), f.pr.PRNumber)
 }
+
+func (f *FakeGitHub) issueEventsURL() string {
+	return fmt.Sprintf("/repos/%s/issues/%d/events", f.repoFullName(), f.pr.PRNumber)
+}


### PR DESCRIPTION
This PR:
-  introduces functionality that ignores team members as approvers who have reopened the PR. 
- adds additional pact tests 
- adds additional unit/ integration tests 

Consequences:
- Globally ignores all reopeners as allowed approvers 